### PR TITLE
Added functionality to calculate classpath to include the slf4j jar files

### DIFF
--- a/src/StanfordNLP/Base.php
+++ b/src/StanfordNLP/Base.php
@@ -122,6 +122,26 @@ class Base {
     }
 
     /**
+     * JavaCP getter
+     *
+     * Added by bryangruneberg to fix the code that calls JAVA
+     *
+     * @return mixed
+     */
+    public function getJarCP()
+    {
+        $osSeparator = $this->php_os == 'windows' ? ';' : ':';
+	$path_parts = pathinfo($this->getJar());
+	print_r($path_parts);
+	
+	$CP = $path_parts["dirname"] . DIRECTORY_SEPARATOR . "lib/slf4j-api.jar" . $osSeparator 
+	 	. $path_parts["dirname"] . DIRECTORY_SEPARATOR . "lib/slf4j-simple.jar" . $osSeparator 
+		. $this->getJar() . $osSeparator;
+	
+	return $CP;
+    }
+
+    /**
      * Models Jar setter
      *
      * @param $jar string path to jar file

--- a/src/StanfordNLP/Parser.php
+++ b/src/StanfordNLP/Parser.php
@@ -91,7 +91,7 @@ class Parser extends Base {
         $osSeparator = $this->php_os == 'windows' ? ';' : ':';
         $cmd = $this->getJavaPath()
             . " $options -cp \""
-            . $this->getJar()
+            . $this->getJarCP()
             . $osSeparator
             . $this->getModelsJar()
             . '" edu.stanford.nlp.parser.lexparser.LexicalizedParser -encoding UTF-8 -outputFormat "'

--- a/src/StanfordNLP/StanfordTagger.php
+++ b/src/StanfordNLP/StanfordTagger.php
@@ -132,7 +132,7 @@ class StanfordTagger extends Base {
                 $cmd = escapeshellcmd(
                     $this->getJavaPath()
                     . " $options -cp \""
-                    . $this->getJar()
+                    . $this->getJarCP()
                     . "{$osSeparator}\" edu.stanford.nlp.tagger.maxent.MaxentTagger -model "
                     . $this->getModel()
                     . " -textFile "
@@ -146,7 +146,7 @@ class StanfordTagger extends Base {
                 $cmd = escapeshellcmd(
                     $this->getJavaPath()
                     . " $options -cp \""
-                    . $this->getJar()
+                    . $this->getJarCP()
                     . "{$osSeparator}\" edu.stanford.nlp.ie.crf.CRFClassifier -loadClassifier "
                     . $this->getClassifier()
                     . " -textFile "
@@ -155,6 +155,8 @@ class StanfordTagger extends Base {
                 );
             break;
         }
+
+	echo "Running: " . $cmd . "\n";
 
         $process = proc_open($cmd, $descriptorspec, $pipes, dirname($this->getJar()));
 


### PR DESCRIPTION
The java call was silently failing. This code uses getJar() to determine the directory of the slf4j far files distributed with the Stanford-NLP zip
