### PR TITLE
Fix "outputs first sentence only" bug.

### DIFF
--- a/src/StanfordNLP/StanfordTagger.php
+++ b/src/StanfordNLP/StanfordTagger.php
@@ -88,7 +88,7 @@ class StanfordTagger extends Base {
     public function tag($tokens)
     {
         $results = $this->batchTag(array($tokens));
-        return isset($results[0]) ? $results[0] : array();
+        return isset($results) ? $results : array();
     }
 
     /**


### PR DESCRIPTION
This addresses https://github.com/agentile/PHP-Stanford-NLP/issues/15 
However the output of `tag` will now have one more dimension of the array returned to account for multiple sentences.
