### PR TITLE
Update StanfordTagger.php

### DIFF
--- a/src/StanfordNLP/StanfordTagger.php
+++ b/src/StanfordNLP/StanfordTagger.php
@@ -136,7 +136,7 @@ class StanfordTagger extends Base {
                     . "{$osSeparator}\" edu.stanford.nlp.tagger.maxent.MaxentTagger -model "
                     . $this->getModel()
                     . " -textFile "
-                    . $tmpfname
+                    . "\"$tmpfname\""
                     . " -outputFormat slashTags -tagSeparator "
                     . $separator
                     . " -encoding utf8"


### PR DESCRIPTION
Added support for system users with spaces in their user directories by wrapping the tmpfname variable within the batchTag method in quotes.